### PR TITLE
Added support to run the mock service on SSL. Important for browser-based consumers.

### DIFF
--- a/lib/pact/mock_service/cli.rb
+++ b/lib/pact/mock_service/cli.rb
@@ -52,7 +52,6 @@ module Pact
           :SSLEnable => true,
           :SSLCertName => [ %w[CN localhost] ] }) if options[:ssl]
 
-        puts options
         Rack::Handler::WEBrick.run(mock_service, webbrick_opts)
       end
     end

--- a/lib/pact/mock_service/cli.rb
+++ b/lib/pact/mock_service/cli.rb
@@ -1,6 +1,7 @@
 require 'find_a_port'
 require 'thor'
 require 'thwait'
+require 'webrick/https'
 require 'rack/handler/webrick'
 
 # TODO rename CLI so as not to clash
@@ -11,6 +12,7 @@ module Pact
 
       desc 'service', "Start a mock service"
       method_option :port, aliases: "-p", desc: "Port on which to run the service"
+      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over https"
       method_option :log, aliases: "-l", desc: "File to which to log output"
       method_option :quiet, aliases: "-q", desc: "If true, no admin messages will be shown"
 
@@ -38,10 +40,22 @@ module Pact
           service_options[:log_file] = log
         end
 
-        port = options[:port] || FindAPort.available_port
+        cert_name =
+
         mock_service = Pact::Consumer::MockService.new(service_options)
         trap(:INT) { Rack::Handler::WEBrick.shutdown }
-        Rack::Handler::WEBrick.run(mock_service, :Port => port, :AccessLog => [])
+
+        webbrick_opts = {
+          :Port => options[:port] || FindAPort.available_port,
+          :AccessLog => []
+        }
+
+        webbrick_opts.merge!({
+          :SSLEnable => true,
+          :SSLCertName => [ %w[CN localhost] ] }) if options[:ssl]
+
+        puts options
+        Rack::Handler::WEBrick.run(mock_service, webbrick_opts)
       end
     end
 

--- a/lib/pact/mock_service/cli.rb
+++ b/lib/pact/mock_service/cli.rb
@@ -40,8 +40,6 @@ module Pact
           service_options[:log_file] = log
         end
 
-        cert_name =
-
         mock_service = Pact::Consumer::MockService.new(service_options)
         trap(:INT) { Rack::Handler::WEBrick.shutdown }
 


### PR DESCRIPTION
Very simple change to add a --ssl option to the mock_service CLI. Allows it to run with a self-signed certificate.

This is very helpful for testing browser-based consumers.

(redone pull req. from branch)