### PR TITLE
Fixing path

### DIFF
--- a/lib/pact/mock_service.rb
+++ b/lib/pact/mock_service.rb
@@ -1,2 +1,2 @@
-require 'pact/consumer/app_manager'
+require 'pact/mock_service/app_manager'
 require 'pact/mock_service/app'


### PR DESCRIPTION
Install on clean server fails 
with /home/andre/.rvm/gems/ruby-2.1.2/gems/backports-3.6.4/lib/backports/std_lib.rb:9:in `require': cannot load such file -- pact/consumer/app_manager

This fixes it, by using the available app_manager