### PR TITLE
Produce a valid rack response on interaction post error

### DIFF
--- a/lib/pact/mock_service/request_handlers/interaction_post.rb
+++ b/lib/pact/mock_service/request_handlers/interaction_post.rb
@@ -27,7 +27,7 @@ module Pact
             session.add_expected_interaction interaction
             [200, {}, ['Set interactions']]
           rescue AlmostDuplicateInteractionError => e
-            [500, {}, e.message]
+            [500, {}, [e.message]]
           end
 
         end

--- a/spec/lib/pact/mock_service/request_handlers/interaction_post_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/interaction_post_spec.rb
@@ -4,7 +4,43 @@ module Pact
   module MockService
     module RequestHandlers
       describe InteractionPost do
+        let(:session) { instance_double('Pact::MockService::Session') }
+        let(:logger) { double('Logger').as_null_object }
+        let(:interaction_json) {
+          {
+            description: "some description",
+            provider_state: "some state",
+            request: { method: "put", path: "/" },
+            response: { status: 200, headers: {} }
+          }.to_json
+        }
 
+        let(:rack_env) do
+          {
+            'rack.input' => StringIO.new(interaction_json)
+          }
+        end
+
+        subject { described_class.new '', logger, session }
+
+        context "adding the interaction will raise AlmostDuplicateInteractionError" do
+          let(:message) { "my message" }
+
+          before(:each) do
+            allow(session).to receive(:add_expected_interaction).and_raise(AlmostDuplicateInteractionError.new(message))
+          end
+
+          it "has 500 status" do
+            status, _, _ = subject.respond(rack_env)
+            expect(status).to eq(500)
+          end
+
+          it "returns a valid rack response with an error message" do
+            _, _, body_iterable = subject.respond(rack_env)
+            expect(body_iterable).to respond_to(:each)
+            expect(body_iterable.join).to eq(message)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
The third element of a rack return value should respond to `#each`, but in the error scenario it was returning a plain string, rather than an array.

I was getting an error adding one of my interactions, but the error message I saw was:

```
RuntimeError: <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
<HTML>
  <HEAD><TITLE>Internal Server Error</TITLE></HEAD>
  <BODY>
    <H1>Internal Server Error</H1>
    undefined method `each' for #&lt;String:0x007f8e62ae5b58&gt;
    <HR>
    <ADDRESS>
     WEBrick/1.3.1 (Ruby/2.1.5/2014-11-13) at
     localhost:3077
    </ADDRESS>
  </BODY>
</HTML>
```

with this change, I now see:

```
RuntimeError: An interaction with same description ("PUT new entry") and
provider state ("an empty content register") but a different request
path, response status and response body has already been used. Please
use a different description or provider state.
```

which is much more helpful :-)

Also added a corresponding unit test