### PR TITLE
Added a CLI option to alter binding address

### DIFF
--- a/lib/pact/mock_service/cli.rb
+++ b/lib/pact/mock_service/cli.rb
@@ -12,6 +12,7 @@ module Pact
 
       desc 'service', "Start a mock service. If the consumer, provider and pact-dir options are provided, the pact will be written automatically on shutdown."
       method_option :port, aliases: "-p", desc: "Port on which to run the service"
+      method_option :bindAddress, aliases: "-b", desc: "Address to bind service to"
       method_option :log, aliases: "-l", desc: "File to which to log output"
       method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS"
       method_option :cors, aliases: "-o", desc: "Support browser security in tests by responding to OPTIONS requests and adding CORS headers to mocked responses"

--- a/lib/pact/mock_service/run.rb
+++ b/lib/pact/mock_service/run.rb
@@ -67,6 +67,7 @@ module Pact
       def webbrick_opts
         opts = {
           :Port => port,
+          :Host => bindAddress,
           :AccessLog => []
         }
         opts.merge!(ssl_opts) if options[:ssl]
@@ -84,8 +85,12 @@ module Pact
         @port ||= options[:port] || FindAPort.available_port
       end
 
+      def bindAddress
+        @bindAddress ||= options[:bindAddress] || "localhost"
+      end
+
       def base_url
-        options[:ssl] ? "https://localhost:#{port}" : "http://localhost:#{port}"
+        options[:ssl] ? "https://#{bindAddress}:#{port}" : "http://#{bindAddress}:#{port}"
       end
     end
   end


### PR DESCRIPTION
This allows the mock service to be run on an interface
other than localhost.

We have been using this run the mock service inside a
docker container and be called from a linked
container.