### PR TITLE
fixing wrapper to work with both symlinked and non-symlinked files

### DIFF
--- a/packaging/wrapper.sh
+++ b/packaging/wrapper.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 set -e
 
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  TARGET="$(readlink "$SOURCE")"
+  if [[ $TARGET == /* ]]; then
+    SOURCE="$TARGET"
+  else
+    DIR="$( dirname "$SOURCE" )"
+    SOURCE="$DIR/$TARGET" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  fi
+done
+RDIR="$( dirname "$SOURCE" )"
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
 # Figure out where this script is located.
-SELFDIR="`dirname \"$0\"`"
-SELFDIR="`cd \"$SELFDIR\" && cd .. && pwd`"
+LIBDIR="`cd \"$DIR\" && cd ../lib && pwd`"
 
 # Tell Bundler where the Gemfile and gems are.
-export BUNDLE_GEMFILE="$SELFDIR/lib/vendor/Gemfile"
+export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.
-exec "$SELFDIR/lib/ruby/bin/ruby" -rbundler/setup -I$SELFDIR/lib/app/lib "$SELFDIR/lib/app/pact-mock-service.rb" $@
+exec "$LIBDIR/ruby/bin/ruby" -rbundler/setup -I$LIBDIR/app/lib "$LIBDIR/app/pact-mock-service.rb" $@


### PR DESCRIPTION
This will fix https://github.com/bethesque/pact-mock-service-npm/issues/1 for both linux and osx.  The bat file seems to already work with the Windows packaging.

Is it possible to repackage after this so that the latest can be used in node?

Cheers.