### PR TITLE
Adds DELETE session endpoint

### DIFF
--- a/lib/pact/mock_service/request_handlers.rb
+++ b/lib/pact/mock_service/request_handlers.rb
@@ -7,6 +7,7 @@ require 'pact/mock_service/request_handlers/log_get'
 require 'pact/mock_service/request_handlers/options'
 require 'pact/mock_service/request_handlers/missing_interactions_get'
 require 'pact/mock_service/request_handlers/pact_post'
+require 'pact/mock_service/request_handlers/session_delete'
 require 'pact/mock_service/request_handlers/verification_get'
 require 'pact/consumer/request'
 require 'pact/support'
@@ -23,6 +24,7 @@ module Pact
         def initialize name, logger, session, options
           super [
             Options.new(name, logger, options[:cors_enabled]),
+            SessionDelete.new(name, logger, session),
             MissingInteractionsGet.new(name, logger, session),
             VerificationGet.new(name, logger, session),
             InteractionPost.new(name, logger, session),

--- a/lib/pact/mock_service/request_handlers/session_delete.rb
+++ b/lib/pact/mock_service/request_handlers/session_delete.rb
@@ -1,0 +1,33 @@
+require 'pact/mock_service/request_handlers/base_administration_request_handler'
+
+module Pact
+  module MockService
+    module RequestHandlers
+
+      class SessionDelete < BaseAdministrationRequestHandler
+
+        attr_accessor :session
+
+        def initialize name, logger, session
+          super name, logger
+          @session = session
+        end
+
+        def request_path
+          '/session'
+        end
+
+        def request_method
+          'DELETE'
+        end
+
+        def respond env
+          session.clear_all
+          logger.info "Cleared session"
+          [200, {}, ['Cleared session']]
+        end
+
+      end
+    end
+  end
+end

--- a/lib/pact/mock_service/session.rb
+++ b/lib/pact/mock_service/session.rb
@@ -39,6 +39,12 @@ module Pact
         actual_interactions.clear
       end
 
+      def clear_all
+        expected_interactions.clear
+        actual_interactions.clear
+        verified_interactions.clear
+      end
+
       def add_expected_interaction interaction
         if (previous_interaction = interaction_already_verified_with_same_description_and_provider_state_but_not_equal(interaction))
           handle_almost_duplicate_interaction previous_interaction, interaction

--- a/spec/features/log/mock_multiple_responses_spec.log
+++ b/spec/features/log/mock_multiple_responses_spec.log
@@ -1,101 +1,3 @@
-INFO -- : Cleared interactions before example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"
-INFO -- : Registered expected interaction GET /alligators
-DEBUG -- : {
-  "description": "a request for alligators",
-  "provider_state": "alligators exist",
-  "request": {
-    "method": "get",
-    "path": "/alligators",
-    "headers": {
-      "Accept": "application/json"
-    }
-  },
-  "response": {
-    "status": 200,
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "body": [
-      {
-        "name": "Mary"
-      }
-    ]
-  }
-}
-INFO -- : Registered expected interaction GET /zebras
-DEBUG -- : {
-  "description": "a request for zebras",
-  "provider_state": "there are zebras",
-  "request": {
-    "method": "get",
-    "path": "/zebras",
-    "headers": {
-      "Accept": "application/json"
-    }
-  },
-  "response": {
-    "status": 200,
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "body": [
-      {
-        "name": "Xena Zebra"
-      }
-    ]
-  }
-}
-INFO -- : Received request GET /alligators
-DEBUG -- : {
-  "method": "get",
-  "query": "",
-  "path": "/alligators",
-  "headers": {
-    "Https": "off",
-    "Content-Length": "0",
-    "Accept": "application/json",
-    "Host": "example.org",
-    "Cookie": ""
-  }
-}
-INFO -- : Found matching response for GET /alligators
-DEBUG -- : {
-  "status": 200,
-  "headers": {
-    "Content-Type": "application/json"
-  },
-  "body": [
-    {
-      "name": "Mary"
-    }
-  ]
-}
-INFO -- : Received request GET /zebras
-DEBUG -- : {
-  "method": "get",
-  "query": "",
-  "path": "/zebras",
-  "headers": {
-    "Https": "off",
-    "Content-Length": "0",
-    "Accept": "application/json",
-    "Host": "example.org",
-    "Cookie": ""
-  }
-}
-INFO -- : Found matching response for GET /zebras
-DEBUG -- : {
-  "status": 200,
-  "headers": {
-    "Content-Type": "application/json"
-  },
-  "body": [
-    {
-      "name": "Xena Zebra"
-    }
-  ]
-}
-INFO -- : Verifying - interactions matched for example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"
 INFO -- : Cleared interactions before example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches more than one expected request returns an error response"
 INFO -- : Registered expected interaction GET /alligators
 DEBUG -- : {
@@ -208,3 +110,101 @@ WARN -- : Missing requests:
 	GET /alligators
 
 
+INFO -- : Cleared interactions before example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"
+INFO -- : Registered expected interaction GET /alligators
+DEBUG -- : {
+  "description": "a request for alligators",
+  "provider_state": "alligators exist",
+  "request": {
+    "method": "get",
+    "path": "/alligators",
+    "headers": {
+      "Accept": "application/json"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": [
+      {
+        "name": "Mary"
+      }
+    ]
+  }
+}
+INFO -- : Registered expected interaction GET /zebras
+DEBUG -- : {
+  "description": "a request for zebras",
+  "provider_state": "there are zebras",
+  "request": {
+    "method": "get",
+    "path": "/zebras",
+    "headers": {
+      "Accept": "application/json"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": [
+      {
+        "name": "Xena Zebra"
+      }
+    ]
+  }
+}
+INFO -- : Received request GET /alligators
+DEBUG -- : {
+  "method": "get",
+  "query": "",
+  "path": "/alligators",
+  "headers": {
+    "Https": "off",
+    "Content-Length": "0",
+    "Accept": "application/json",
+    "Host": "example.org",
+    "Cookie": ""
+  }
+}
+INFO -- : Found matching response for GET /alligators
+DEBUG -- : {
+  "status": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": [
+    {
+      "name": "Mary"
+    }
+  ]
+}
+INFO -- : Received request GET /zebras
+DEBUG -- : {
+  "method": "get",
+  "query": "",
+  "path": "/zebras",
+  "headers": {
+    "Https": "off",
+    "Content-Length": "0",
+    "Accept": "application/json",
+    "Host": "example.org",
+    "Cookie": ""
+  }
+}
+INFO -- : Found matching response for GET /zebras
+DEBUG -- : {
+  "status": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": [
+    {
+      "name": "Xena Zebra"
+    }
+  ]
+}
+INFO -- : Verifying - interactions matched for example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"

--- a/spec/features/log/mock_one_response_spec.log
+++ b/spec/features/log/mock_one_response_spec.log
@@ -1,53 +1,3 @@
-INFO -- : Cleared interactions before example "Pact::Consumer::MockService when a response has been mocked when the actual request matches the expected request returns the expected response"
-INFO -- : Registered expected interaction GET /alligators
-DEBUG -- : {
-  "description": "a request for alligators",
-  "provider_state": "alligators exist",
-  "request": {
-    "method": "get",
-    "path": "/alligators",
-    "headers": {
-      "Accept": "application/json"
-    }
-  },
-  "response": {
-    "status": 200,
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "body": [
-      {
-        "name": "Mary"
-      }
-    ]
-  }
-}
-INFO -- : Received request GET /alligators
-DEBUG -- : {
-  "method": "get",
-  "query": "",
-  "path": "/alligators",
-  "headers": {
-    "Https": "off",
-    "Content-Length": "0",
-    "Accept": "application/json",
-    "Host": "example.org",
-    "Cookie": ""
-  }
-}
-INFO -- : Found matching response for GET /alligators
-DEBUG -- : {
-  "status": 200,
-  "headers": {
-    "Content-Type": "application/json"
-  },
-  "body": [
-    {
-      "name": "Mary"
-    }
-  ]
-}
-INFO -- : Verifying - interactions matched for example "Pact::Consumer::MockService when a response has been mocked when the actual request matches the expected request returns the expected response"
 INFO -- : Cleared interactions before example "Pact::Consumer::MockService when a response has been mocked when the actual request does not match the expected request returns an error response"
 INFO -- : Registered expected interaction GET /alligators
 DEBUG -- : {
@@ -109,3 +59,53 @@ WARN -- : Incorrect requests:
 	GET /alligators (request headers did not match)
 
 
+INFO -- : Cleared interactions before example "Pact::Consumer::MockService when a response has been mocked when the actual request matches the expected request returns the expected response"
+INFO -- : Registered expected interaction GET /alligators
+DEBUG -- : {
+  "description": "a request for alligators",
+  "provider_state": "alligators exist",
+  "request": {
+    "method": "get",
+    "path": "/alligators",
+    "headers": {
+      "Accept": "application/json"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": [
+      {
+        "name": "Mary"
+      }
+    ]
+  }
+}
+INFO -- : Received request GET /alligators
+DEBUG -- : {
+  "method": "get",
+  "query": "",
+  "path": "/alligators",
+  "headers": {
+    "Https": "off",
+    "Content-Length": "0",
+    "Accept": "application/json",
+    "Host": "example.org",
+    "Cookie": ""
+  }
+}
+INFO -- : Found matching response for GET /alligators
+DEBUG -- : {
+  "status": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": [
+    {
+      "name": "Mary"
+    }
+  ]
+}
+INFO -- : Verifying - interactions matched for example "Pact::Consumer::MockService when a response has been mocked when the actual request matches the expected request returns the expected response"

--- a/spec/lib/pact/mock_service/request_handlers/session_delete_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/session_delete_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'pact/mock_service/request_handlers/session_delete'
+
+module Pact
+  module MockService
+    module RequestHandlers
+
+      describe SessionDelete do
+
+        let(:session) { instance_double('Pact::MockService::Session', clear_all: nil)}
+        let(:logger) { double('Logger').as_null_object }
+        let(:rack_env) do
+          {}
+        end
+
+        subject { SessionDelete.new '', logger, session }
+
+        it "clears the entire session" do
+          expect(session).to receive(:clear_all)
+          subject.respond rack_env
+        end
+
+      end
+    end
+  end
+end

--- a/spec/lib/pact/mock_service/session_spec.rb
+++ b/spec/lib/pact/mock_service/session_spec.rb
@@ -39,6 +39,37 @@ module Pact::MockService
 
     end
 
+    describe "clear_all" do
+
+      let(:expected_interactions) { instance_double('Interactions::ExpectedInteractions', clear: nil, :<< => nil) }
+      let(:actual_interactions) { instance_double('Interactions::ActualInteractions', clear: nil) }
+      let(:verified_interactions) { instance_double('Interactions::VerifiedInteractions', clear: nil) }
+
+      before do
+        allow(Interactions::ExpectedInteractions).to receive(:new).and_return(expected_interactions)
+        allow(Interactions::ActualInteractions).to receive(:new).and_return(actual_interactions)
+        allow(Interactions::VerifiedInteractions).to receive(:new).and_return(verified_interactions)
+      end
+
+      subject { Session.new(logger: logger).clear_all }
+
+      it "clears the expected interactions" do
+        expect(expected_interactions).to receive(:clear)
+        subject
+      end
+
+      it "clears the actual interactions" do
+        expect(actual_interactions).to receive(:clear)
+        subject
+      end
+
+      it "clears the verified interactions" do
+        expect(verified_interactions).to receive(:clear)
+        subject
+      end
+
+    end
+
     describe "add_expected_interaction" do
       let(:interaction_1) { InteractionFactory.create }
       let(:interaction_2) { InteractionFactory.create }


### PR DESCRIPTION
	Adds support to clear an entire session to allow
	long lived pact mock servers.  This is useful when repeatedly
	testing against the same server process

	Tests can invoke DELETE /session to flush out all:
		- expected interactions
		- actual interactions
		- verified interactions