### PR TITLE
Added a README example of using the pack-mock-server as a stub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ See the [releases][releases] page for the latest standalone executables.
 
 I had a package somewhere lying around, but I lost it, and I don't have a Windows machine. If you are interested in using the mock server on Windows, please check out the instructions for building one [here][windows], and then let me know so I can upload it to the releases page. Thanks!
 
+### Stubbing a service based on a previously generated pact file
+
+It is sometimes useful to be able to run a known service as a stub (a non-verified mock) in order to isolate your system under test.
+
+This example assumes your have already created a Pact contract describing the services expected behaviour, and that you have pact mock server installed correctly.
+
+First we need to run the pact mock service
+
+    pact-mock-service control --port=1234 --pact-specification-version=2.0.0
+
+Now we need to upload our pact file that describes what requests to expect and what responses should be given.
+
+    curl -X PUT \
+    -H "Content-Type: application/json" \
+    -H "X-Pact-Consumer: ExampleConsumer" \
+    -H "X-Pact-Provider: ExampleProvider" \
+    -d @ExampleConsumer-ExampleProvider.json \
+    http://localhost:1234/interactions
+
+We can now test our mock by curling to it as if it was a normal service with a couple of extra headers. In this example the pact file describes an endpoint called 'helloworld'.
+
+    curl http://localhost:1234/helloworld \
+    -H "X-Pact-Consumer: ExampleProvider" \
+    -H "X-Pact-Provider: UpstreamService"
+
 ## Contributing
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md)


### PR DESCRIPTION
Hi,

You have a great tool here that I nearly ignored and reimplemented due to lack of documentation! :-)

I don't mind if you don't use this change, or if you correct / expand / rewrite it, but please do the poor souls trying to use your lovely software a favour and put in something like this in for us. Also if I've got it wrong please god tell me because it took me ages to piece together it's usage - simple as it is.

I'm not a ruby developer so picking through the source code and trawling google groups for clues was not fun. What I (and people like me) need is simple, vanilla usage examples - hence why I've used curl. You have an example of starting the server but I was like "Great! Now what...?" :-)

I still have no idea what else pact mock service can do!

As a side note, again not being a Ruby developer I tried downloading the standalone release, expanded the zip, recoiled in terror at the volume of stuff in there, and decided it was be less hassle and more obvious to install Ruby with homebrew. I wonder if it would be possible to boil standalone releases down to less files or reorganise the folder structure so that it was blindingly obvious what to do with it. e.g. an executable (the only bit I care about - could even be a shell script to invokes the app delegating arguments to the real programme?), a readme and a folder containing all the other stuff / dragons / voodoo.

Thanks and keep up the good work, I'll be looking at pack broker later so you might get another one of these...

Dave