### PR TITLE
allowing PATCH method in the CORS handler

### DIFF
--- a/lib/pact/mock_service/request_handlers/options.rb
+++ b/lib/pact/mock_service/request_handlers/options.rb
@@ -22,7 +22,7 @@ module Pact
           cors_headers = {
            'Access-Control-Allow-Origin' => env.fetch('HTTP_ORIGIN','*'),
            'Access-Control-Allow-Headers' => headers_from(env)["Access-Control-Request-Headers"],
-           'Access-Control-Allow-Methods' => 'DELETE, POST, GET, HEAD, PUT, TRACE, CONNECT'
+           'Access-Control-Allow-Methods' => 'DELETE, POST, GET, HEAD, PUT, TRACE, CONNECT, PATCH'
           }
           logger.info "Received OPTIONS request for mock service administration endpoint #{env['HTTP_ACCESS_CONTROL_REQUEST_METHOD']} #{env['PATH_INFO']}. Returning CORS headers: #{cors_headers.to_json}."
           [200, cors_headers, []]


### PR DESCRIPTION
We have a bunch of APIs that are using PATCHes rather than PUTs and not having it in the `Access-Control-Allow-Methods` causes pact failures. This is a simplest change ever, but if we want to make it a bit more intelligent and, say, cater for any HTTP verb, or being able to configure which verbs are allowed somehow - I'm happy to do that.