### PR TITLE
[Proposal] Add option not to write pact file

### DIFF
--- a/lib/pact/consumer_contract/consumer_contract_writer.rb
+++ b/lib/pact/consumer_contract/consumer_contract_writer.rb
@@ -34,7 +34,7 @@ module Pact
     end
 
     def write
-      update_pactfile
+      update_pactfile unless pactfile_write_mode == :none
       pact_json
     end
 

--- a/spec/lib/pact/consumer_contract/consumer_contract_writer_spec.rb
+++ b/spec/lib/pact/consumer_contract/consumer_contract_writer_spec.rb
@@ -122,7 +122,16 @@ module Pact
           pact_hash =JSON.parse(File.read(target_pact_file_location))
           expect(pact_hash['interactions'].size).to eq 3
         end
+      end
 
+      context "when pactfile_write_mode is none" do
+        let(:pactfile_write_mode) { :none }
+        before { FileUtils.rm_rf target_pact_file_location }
+
+        it "does not write the pact file" do
+          consumer_contract_writer.write
+          expect(File.exist?(target_pact_file_location)).to be false
+        end
       end
 
       context "when the pact_dir is not specified" do


### PR DESCRIPTION
We don't always need to write pact file. For example, when we have both
local development machine and CI machine, we want to generate only in CI
machine not local development machine.

I want to use this feature by configuring Pact in consumer project's pact_helper like:

```ruby
Pact.configure do |config|
  config.pactfile_write_mode = :none unless ENV['RUN_CI']
end
```

How about supporting this feature?