### PR TITLE
`find_available_port` option

### DIFF
--- a/lib/pact/consumer/server.rb
+++ b/lib/pact/consumer/server.rb
@@ -70,7 +70,9 @@ module Pact
 
     def run_default_server(app, port)
       require 'rack/handler/webrick'
-      Rack::Handler::WEBrick.run(app, webrick_opts)
+      Rack::Handler::WEBrick.run(app, webrick_opts) do |server|
+        @port = server[:Port]
+      end
     end
 
     def get_identity
@@ -83,7 +85,7 @@ module Pact
     end
 
     def webrick_opts
-      opts = {:Port => port, :AccessLog => [], :Logger => WEBrick::Log::new(nil, 0)}
+      opts = {:Port => port.nil? ? 0 : port, :AccessLog => [], :Logger => WEBrick::Log::new(nil, 0)}
       opts.merge!(ssl_opts) if options[:ssl]
       opts
     end
@@ -97,8 +99,6 @@ module Pact
 
     def boot
       unless responsive?
-        Pact::Server.ports[@app.object_id] = @port
-
         @server_thread = Thread.new do
           run_default_server(@middleware, @port)
         end
@@ -108,8 +108,8 @@ module Pact
     rescue Timeout::Error
       raise "Rack application timed out during boot"
     else
+      Pact::Server.ports[@app.object_id] = @port
       self
     end
-
   end
 end

--- a/lib/pact/consumer/server.rb
+++ b/lib/pact/consumer/server.rb
@@ -85,24 +85,18 @@ module Pact
     end
 
     def webrick_opts
-      opts = {:Port => port.nil? ? 0 : port, :AccessLog => [], :Logger => WEBrick::Log::new(nil, 0)}
+      opts = {Port: port.nil? ? 0 : port, AccessLog: [], Logger: WEBrick::Log::new(nil, 0)}
       opts.merge!(ssl_opts) if options[:ssl]
       opts
     end
 
     def ssl_opts
-      {
-        :SSLEnable => true,
-        :SSLCertName => [ %w[CN localhost] ]
-      }
+      { SSLEnable: true, SSLCertName: [ %w[CN localhost] ] }
     end
 
     def boot
       unless responsive?
-        @server_thread = Thread.new do
-          run_default_server(@middleware, @port)
-        end
-
+        @server_thread = Thread.new { run_default_server(@middleware, @port) }
         Timeout.timeout(60) { @server_thread.join(0.1) until responsive? }
       end
     rescue Timeout::Error

--- a/lib/pact/consumer/server.rb
+++ b/lib/pact/consumer/server.rb
@@ -76,6 +76,7 @@ module Pact
     end
 
     def get_identity
+      return false unless @port
       http = Net::HTTP.new host, @port
       if options[:ssl]
         http.use_ssl = true

--- a/lib/pact/mock_service/app_manager.rb
+++ b/lib/pact/mock_service/app_manager.rb
@@ -20,21 +20,27 @@ module Pact
         @app_registrations = []
       end
 
-      def register_mock_service_for name, url, options = {}
+      def register_mock_service_for(name, url, options = {})
         uri = URI(url)
         raise "Currently only http is supported" unless uri.scheme == 'http'
         raise "Currently only services on localhost are supported" unless uri.host == 'localhost'
         uri.port = nil if options[:find_available_port]
 
-        register(Pact::MockService.new(log_file: create_log_file(name), name: name, pact_dir: pact_dir, pact_specification_version: options[:pact_specification_version]), uri.port)
+        app = Pact::MockService.new(
+          name: name,
+          log_file: create_log_file(name),
+          pact_dir: pact_dir,
+          pact_specification_version: options[:pact_specification_version]
+        )
+        register(app, uri.port)
       end
 
       def register(app, port = nil)
         if port
-          existing = existing_app_on_port port
+          existing = existing_app_on_port(port)
           raise "Port #{port} is already being used by #{existing}" if existing and not existing == app
         end
-        app_registration = register_app app, port
+        app_registration = register_app(app, port)
         app_registration.spawn
         app_registration.port
       end
@@ -64,12 +70,12 @@ module Pact
 
       private
 
-      def existing_app_on_port port
-        app_registration = registration_on_port port
+      def existing_app_on_port(port)
+        app_registration = registration_on_port(port)
         app_registration ? app_registration.app : nil
       end
 
-      def registration_on_port port
+      def registration_on_port(port)
         @app_registrations.find { |app_registration| app_registration.port == port }
       end
 
@@ -77,18 +83,18 @@ module Pact
         Pact.configuration.pact_dir
       end
 
-      def create_log_file service_name
-        FileUtils::mkdir_p Pact.configuration.log_dir
+      def create_log_file(service_name)
+        FileUtils::mkdir_p(Pact.configuration.log_dir)
         log = File.open(log_file_path(service_name), 'w')
         log.sync = true
         log
       end
 
-      def log_file_path service_name
+      def log_file_path(service_name)
         File.join(Pact.configuration.log_dir, "#{log_file_name(service_name)}.log")
       end
 
-      def log_file_name service_name
+      def log_file_name(service_name)
         lower_case_name = service_name.downcase.gsub(/\s+/, '_')
         if lower_case_name.include?('_service')
           lower_case_name.gsub('_service', '_mock_service')
@@ -101,8 +107,8 @@ module Pact
         @app_registrations
       end
 
-      def register_app app, port
-        app_registration = AppRegistration.new :app => app, :port => port
+      def register_app(app, port)
+        app_registration = AppRegistration.new(app: app, port: port)
         app_registrations << app_registration
         app_registration
       end
@@ -110,10 +116,9 @@ module Pact
 
     class AppRegistration
       include Pact::Logging
-      attr_accessor :port
-      attr_accessor :app
+      attr_accessor :port, :app
 
-      def initialize opts
+      def initialize(opts)
         @max_wait = 10
         @port = opts[:port]
         @app = opts[:app]
@@ -134,7 +139,7 @@ module Pact
       end
 
       def is_a_mock_service?
-        app.is_a? Pact::MockService::App
+        app.is_a?(Pact::MockService::App)
       end
 
       def to_s

--- a/lib/pact/mock_service/run.rb
+++ b/lib/pact/mock_service/run.rb
@@ -83,7 +83,7 @@ module Pact
       end
 
       def port
-        @port ||= options[:port] || FindAPort.available_port
+        @port ||= (options[:port] || FindAPort.available_port).to_i
       end
 
       def host

--- a/spec/lib/pact/consumer/server_spec.rb
+++ b/spec/lib/pact/consumer/server_spec.rb
@@ -1,0 +1,22 @@
+require 'pact/consumer/server'
+
+describe Pact::Server do
+  describe 'booting' do
+    context 'with `nil` port' do
+      let(:app) { double(:app) }
+      let(:webrick_server) { { Port: 1234 } }
+      let(:server) { described_class.new(app, nil) }
+      before { allow(server).to receive(:responsive?).and_return(false, true) }
+
+      it 'boots server with port 0 trick' do
+        expect(Rack::Handler::WEBrick).to receive(:run).
+          with(anything, hash_including(Port: 0)).
+          and_yield(webrick_server)
+
+        expect(server.port).to be_nil
+        Timeout.timeout(3) { server.boot } # Raise when something failed and waits for that
+        expect(server.port).to eq(1234)
+      end
+    end
+  end
+end

--- a/spec/lib/pact/consumer/server_spec.rb
+++ b/spec/lib/pact/consumer/server_spec.rb
@@ -3,19 +3,14 @@ require 'pact/consumer/server'
 describe Pact::Server do
   describe 'booting' do
     context 'with `nil` port' do
-      let(:app) { double(:app) }
-      let(:webrick_server) { { Port: 1234 } }
+      let(:app) { -> (env) { [200, {}, ['OK']] } }
       let(:server) { described_class.new(app, nil) }
-      before { allow(server).to receive(:responsive?).and_return(false, true) }
 
       it 'boots server with port 0 trick' do
-        expect(Rack::Handler::WEBrick).to receive(:run).
-          with(anything, hash_including(Port: 0)).
-          and_yield(webrick_server)
-
         expect(server.port).to be_nil
-        Timeout.timeout(3) { server.boot } # Raise when something failed and waits for that
-        expect(server.port).to eq(1234)
+        Timeout.timeout(10) { server.boot } # Raise when something failed and waits for that
+        expect(server.port).to be_a(Integer)
+        expect(server.port).to be > 0
       end
     end
   end

--- a/spec/lib/pact/mock_service/app_manager_spec.rb
+++ b/spec/lib/pact/mock_service/app_manager_spec.rb
@@ -56,6 +56,15 @@ module Pact::MockService
           expect { AppManager.instance.register_mock_service_for name, url }.to raise_error "Currently only services on localhost are supported"
         end
       end
+
+      describe "find_a_port option" do
+        let(:url) { 'http://localhost' }
+
+        it "builds AppRegistration with `nil` port" do
+          expect(AppRegistration).to receive(:new).with(hash_including(port: nil)).and_call_original
+          AppManager.instance.register_mock_service_for name, url, find_available_port: true
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The actual changes are fbea6d4.

The big change is spawn mock servers as soon as configured mock services.
Previously, they were spawned in RSpec's before suite hook.
This is because we have to obtain actual port and return it to caller. The caller is
`Pact::Consumer::Configuration::MockService#register_mock_service` and it
have to set returned port as soon as call `register_mock_service_for`.

Since booting mock servers is not time consumption task in pact-mock_service,
I think this change may be acceptable. I might be able to plan alternatives to
boot mock servers in before suite hook by making more changes to pact gem,
though.

How do you think?

We use [RRRSpec](https://github.com/cookpad/rrrspec) to run RSpec tests heavy concurrently. I tested this patch in that environment and it looks working finely.

---

The find_a_port gem does not have enough implementation as it writes
that in code comment. In heavy paralleled environment, the released
port which find_a_port gem returns will be used another process and
it causes conflict.

If find_available_port option is on, find and use available port with
"bind(2) with port '0' trick".

`Rack::Handler::WEBrick.run` just passes given options to
`WEBrick::HTTPServer`. And it yields an instance of
`WEBrick::HTTPServer` later.
https://github.com/rack/rack/blob/1.6.4/lib/rack/handler/webrick.rb#L31-L33

`WEBrick::HTTPserver#initialize` passes port to `#listen` which finally
call `bind(2)` with passed port. And it insert back actual bound port to
config hash.
https://github.com/ruby/ruby/blob/v2_3_0/lib/webrick/server.rb#L115-L117

`WEBrick::HTTPServer#listen` just calls
`WEBrick::Utils.create_listeners`
https://github.com/ruby/ruby/blob/v2_3_0/lib/webrick/server.rb#L134

`WEBrick::Utils.create_listeners` creates TCP server sockets by calling
`Socket.tcp_server_sockets` with port=0.
https://github.com/ruby/ruby/blob/v2_3_0/lib/webrick/utils.rb#L61-L73

`Socket.tcp_server_sockets` calls its `.tcp_server_sockets_port0` with
port 0.
https://github.com/ruby/ruby/blob/v2_3_0/ext/socket/lib/socket.rb#L751-L753

`Socket.tcp_server_sockets_port0` creates `Addrinfo` objects with
`port=0` and calls its `.ip_sockets_port0` with `Addrinfo` objects.
https://github.com/ruby/ruby/blob/v2_3_0/ext/socket/lib/socket.rb#L699-L711

`Socket.ip_sockets_port0` creates a `Socket` with given `Addrinfo`
object and calls `Socket#bind` and overwrite port with actual bound port
number.
https://github.com/ruby/ruby/blob/v2_3_0/ext/socket/lib/socket.rb#L663-L694

In `Socket#bind` which is implemented in `sock_bind`, `bind(2)` is
called with `Addrinfo` object which has port as `0`.
https://github.com/ruby/ruby/blob/v2_3_0/ext/socket/socket.c#L567

pact-mock_service still uses find_a_port gem for CLI tool, but in that
case, I think the problem above occurs much fewer times than above case.