### PR TITLE
add host option for control server

### DIFF
--- a/lib/pact/mock_service/cli.rb
+++ b/lib/pact/mock_service/cli.rb
@@ -28,6 +28,7 @@ module Pact
 
       desc 'control', "Run a Pact mock service control server."
       method_option :port, aliases: "-p", desc: "Port on which to run the service"
+      method_option :host, aliases: "-h", desc: "Host on which to bind the service", default: 'localhost'
       method_option :log_dir, aliases: "-l", desc: "File to which to log output"
       method_option :pact_dir, aliases: "-d", desc: "Directory to which the pacts will be written"
       method_option :pact_specification_version, aliases: "-i", desc: "The pact specification version to use when writing the pact", default: '1'

--- a/lib/pact/mock_service/control_server/run.rb
+++ b/lib/pact/mock_service/control_server/run.rb
@@ -59,6 +59,7 @@ module Pact
         def webbrick_opts
           {
             :Port => options[:port],
+            :Host => options[:host],
             :AccessLog => []
           }
         end


### PR DESCRIPTION
This enables to specify 0.0.0.0 as host and enables to reach the mock
server from inside a docker container (see
http://stackoverflow.com/questions/27806631/docker-rails-app-fails-to-be-served-curl-56-recv-failure-connection-reset
).