### PR TITLE
Fixed invalid Rack response on AlmostDuplicateInteractionError

### DIFF
--- a/lib/pact/mock_service/request_handlers/interactions_put.rb
+++ b/lib/pact/mock_service/request_handlers/interactions_put.rb
@@ -28,7 +28,7 @@ module Pact
             session.set_expected_interactions interactions
             [200, {}, ['Set interactions']]
           rescue AlmostDuplicateInteractionError => e
-            [500, {}, e.message]
+            [500, {}, [e.message]]
           end
         end
 


### PR DESCRIPTION
If you set up pact so an `AlmostDuplicateInteractionError` was raised, the webserver would return the following response:

```
[2016-04-18 14:10:25] ERROR NoMethodError: undefined method `each' for #<String:0x007ff1eaa74cc8>
        /Users/aaron/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-1.6.4/lib/rack/handler/webrick.rb:112:in `service'
        /Users/aaron/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/webrick-1.3.1/lib/webrick/httpserver.rb:138:in `service'
        /Users/aaron/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/webrick-1.3.1/lib/webrick/httpserver.rb:94:in `run'
        /Users/aaron/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/webrick-1.3.1/lib/webrick/server.rb:191:in `block in start_thread'
```

This is because `InteractionsPut#respond` was returning an invalid rack response. This change fixes that error.

The POST version of this endpoint is tested in `spec/features/mock_interactions_with_same_description_and_provider_state_spec.rb`, but I didn't see the appropriate place to test this PUT endpoint.