### PR TITLE
Order interactions within the contract by provider state.

### DIFF
--- a/lib/pact/consumer_contract/consumer_contract_decorator.rb
+++ b/lib/pact/consumer_contract/consumer_contract_decorator.rb
@@ -29,6 +29,11 @@ module Pact
     private
 
     def sorted_interactions
+      # Default order: chronological
+      return consumer_contract.interactions if Pact.configuration.pactfile_write_order == :chronological
+      # We are supporting only chronological or alphabetical order
+      raise NotImplementedError if Pact.configuration.pactfile_write_order != :alphabetical
+
       consumer_contract.interactions.sort{|a, b| sortable_id(a) <=> sortable_id(b)}
     end
 

--- a/lib/pact/consumer_contract/consumer_contract_decorator.rb
+++ b/lib/pact/consumer_contract/consumer_contract_decorator.rb
@@ -29,9 +29,11 @@ module Pact
     private
 
     def sorted_interactions
-      consumer_contract.interactions.sort_by do |interaction| 
-        interaction.provider_state || ''
-      end
+      consumer_contract.interactions.sort{|a, b| sortable_id(a) <=> sortable_id(b)}
+    end
+
+    def sortable_id interaction
+      "#{interaction.description.downcase} #{interaction.response.status} #{(interaction.provider_state || '').downcase}"
     end
 
     attr_reader :consumer_contract

--- a/lib/pact/consumer_contract/consumer_contract_decorator.rb
+++ b/lib/pact/consumer_contract/consumer_contract_decorator.rb
@@ -15,7 +15,7 @@ module Pact
       fix_all_the_things(
         consumer: consumer_contract.consumer.as_json,
         provider: consumer_contract.provider.as_json,
-        interactions: consumer_contract.interactions.collect{ |i| InteractionDecorator.new(i, @decorator_options).as_json},
+        interactions: sorted_interactions.collect{ |i| InteractionDecorator.new(i, @decorator_options).as_json},
         metadata: {
           pactSpecificationVersion: pact_specification_version
         }
@@ -27,6 +27,12 @@ module Pact
     end
 
     private
+
+    def sorted_interactions
+      consumer_contract.interactions.sort_by do |interaction| 
+        interaction.provider_state || ''
+      end
+    end
 
     attr_reader :consumer_contract
 

--- a/lib/pact/mock_service/version.rb
+++ b/lib/pact/mock_service/version.rb
@@ -1,5 +1,5 @@
 module Pact
   module MockService
-    VERSION = "0.8.3"
+    VERSION = "0.9.0"
   end
 end

--- a/lib/pact/mock_service/version.rb
+++ b/lib/pact/mock_service/version.rb
@@ -1,5 +1,5 @@
 module Pact
   module MockService
-    VERSION = "0.8.2"
+    VERSION = "0.8.3"
   end
 end

--- a/pact-mock-service.gemspec
+++ b/pact-mock-service.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'json' #Not locking down a version because buncher gem requires 1.6, while other projects use 1.7.
   gem.add_runtime_dependency 'webrick'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'
-  gem.add_runtime_dependency 'pact-support', '~> 0.5.3'
+  gem.add_runtime_dependency 'pact-support', '~> 0.5.8'
 
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'webmock', '~> 1.18.0'

--- a/spec/features/log/mock_multiple_responses_spec.log
+++ b/spec/features/log/mock_multiple_responses_spec.log
@@ -1,101 +1,3 @@
-INFO -- : Cleared interactions before example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"
-INFO -- : Registered expected interaction GET /alligators
-DEBUG -- : {
-  "description": "a request for alligators",
-  "provider_state": "alligators exist",
-  "request": {
-    "method": "get",
-    "path": "/alligators",
-    "headers": {
-      "Accept": "application/json"
-    }
-  },
-  "response": {
-    "status": 200,
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "body": [
-      {
-        "name": "Mary"
-      }
-    ]
-  }
-}
-INFO -- : Registered expected interaction GET /zebras
-DEBUG -- : {
-  "description": "a request for zebras",
-  "provider_state": "there are zebras",
-  "request": {
-    "method": "get",
-    "path": "/zebras",
-    "headers": {
-      "Accept": "application/json"
-    }
-  },
-  "response": {
-    "status": 200,
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "body": [
-      {
-        "name": "Xena Zebra"
-      }
-    ]
-  }
-}
-INFO -- : Received request GET /alligators
-DEBUG -- : {
-  "method": "get",
-  "query": "",
-  "path": "/alligators",
-  "headers": {
-    "Https": "off",
-    "Content-Length": "0",
-    "Accept": "application/json",
-    "Host": "example.org",
-    "Cookie": ""
-  }
-}
-INFO -- : Found matching response for GET /alligators
-DEBUG -- : {
-  "status": 200,
-  "headers": {
-    "Content-Type": "application/json"
-  },
-  "body": [
-    {
-      "name": "Mary"
-    }
-  ]
-}
-INFO -- : Received request GET /zebras
-DEBUG -- : {
-  "method": "get",
-  "query": "",
-  "path": "/zebras",
-  "headers": {
-    "Https": "off",
-    "Content-Length": "0",
-    "Accept": "application/json",
-    "Host": "example.org",
-    "Cookie": ""
-  }
-}
-INFO -- : Found matching response for GET /zebras
-DEBUG -- : {
-  "status": 200,
-  "headers": {
-    "Content-Type": "application/json"
-  },
-  "body": [
-    {
-      "name": "Xena Zebra"
-    }
-  ]
-}
-INFO -- : Verifying - interactions matched for example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"
 INFO -- : Cleared interactions before example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches more than one expected request returns an error response"
 INFO -- : Registered expected interaction GET /alligators
 DEBUG -- : {
@@ -208,3 +110,101 @@ WARN -- : Missing requests:
 	GET /alligators
 
 
+INFO -- : Cleared interactions before example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"
+INFO -- : Registered expected interaction GET /alligators
+DEBUG -- : {
+  "description": "a request for alligators",
+  "provider_state": "alligators exist",
+  "request": {
+    "method": "get",
+    "path": "/alligators",
+    "headers": {
+      "Accept": "application/json"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": [
+      {
+        "name": "Mary"
+      }
+    ]
+  }
+}
+INFO -- : Registered expected interaction GET /zebras
+DEBUG -- : {
+  "description": "a request for zebras",
+  "provider_state": "there are zebras",
+  "request": {
+    "method": "get",
+    "path": "/zebras",
+    "headers": {
+      "Accept": "application/json"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": [
+      {
+        "name": "Xena Zebra"
+      }
+    ]
+  }
+}
+INFO -- : Received request GET /alligators
+DEBUG -- : {
+  "method": "get",
+  "query": "",
+  "path": "/alligators",
+  "headers": {
+    "Https": "off",
+    "Content-Length": "0",
+    "Accept": "application/json",
+    "Host": "example.org",
+    "Cookie": ""
+  }
+}
+INFO -- : Found matching response for GET /alligators
+DEBUG -- : {
+  "status": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": [
+    {
+      "name": "Mary"
+    }
+  ]
+}
+INFO -- : Received request GET /zebras
+DEBUG -- : {
+  "method": "get",
+  "query": "",
+  "path": "/zebras",
+  "headers": {
+    "Https": "off",
+    "Content-Length": "0",
+    "Accept": "application/json",
+    "Host": "example.org",
+    "Cookie": ""
+  }
+}
+INFO -- : Found matching response for GET /zebras
+DEBUG -- : {
+  "status": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": [
+    {
+      "name": "Xena Zebra"
+    }
+  ]
+}
+INFO -- : Verifying - interactions matched for example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"

--- a/spec/features/log/mock_one_response_spec.log
+++ b/spec/features/log/mock_one_response_spec.log
@@ -1,53 +1,3 @@
-INFO -- : Cleared interactions before example "Pact::Consumer::MockService when a response has been mocked when the actual request matches the expected request returns the expected response"
-INFO -- : Registered expected interaction GET /alligators
-DEBUG -- : {
-  "description": "a request for alligators",
-  "provider_state": "alligators exist",
-  "request": {
-    "method": "get",
-    "path": "/alligators",
-    "headers": {
-      "Accept": "application/json"
-    }
-  },
-  "response": {
-    "status": 200,
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "body": [
-      {
-        "name": "Mary"
-      }
-    ]
-  }
-}
-INFO -- : Received request GET /alligators
-DEBUG -- : {
-  "method": "get",
-  "query": "",
-  "path": "/alligators",
-  "headers": {
-    "Https": "off",
-    "Content-Length": "0",
-    "Accept": "application/json",
-    "Host": "example.org",
-    "Cookie": ""
-  }
-}
-INFO -- : Found matching response for GET /alligators
-DEBUG -- : {
-  "status": 200,
-  "headers": {
-    "Content-Type": "application/json"
-  },
-  "body": [
-    {
-      "name": "Mary"
-    }
-  ]
-}
-INFO -- : Verifying - interactions matched for example "Pact::Consumer::MockService when a response has been mocked when the actual request matches the expected request returns the expected response"
 INFO -- : Cleared interactions before example "Pact::Consumer::MockService when a response has been mocked when the actual request does not match the expected request returns an error response"
 INFO -- : Registered expected interaction GET /alligators
 DEBUG -- : {
@@ -109,3 +59,53 @@ WARN -- : Incorrect requests:
 	GET /alligators (request headers did not match)
 
 
+INFO -- : Cleared interactions before example "Pact::Consumer::MockService when a response has been mocked when the actual request matches the expected request returns the expected response"
+INFO -- : Registered expected interaction GET /alligators
+DEBUG -- : {
+  "description": "a request for alligators",
+  "provider_state": "alligators exist",
+  "request": {
+    "method": "get",
+    "path": "/alligators",
+    "headers": {
+      "Accept": "application/json"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": [
+      {
+        "name": "Mary"
+      }
+    ]
+  }
+}
+INFO -- : Received request GET /alligators
+DEBUG -- : {
+  "method": "get",
+  "query": "",
+  "path": "/alligators",
+  "headers": {
+    "Https": "off",
+    "Content-Length": "0",
+    "Accept": "application/json",
+    "Host": "example.org",
+    "Cookie": ""
+  }
+}
+INFO -- : Found matching response for GET /alligators
+DEBUG -- : {
+  "status": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": [
+    {
+      "name": "Mary"
+    }
+  ]
+}
+INFO -- : Verifying - interactions matched for example "Pact::Consumer::MockService when a response has been mocked when the actual request matches the expected request returns the expected response"

--- a/spec/lib/pact/consumer_contract/consumer_contract_decorator_spec.rb
+++ b/spec/lib/pact/consumer_contract/consumer_contract_decorator_spec.rb
@@ -2,13 +2,14 @@ require 'pact/consumer_contract/consumer_contract_decorator'
 
 module Pact
   describe ConsumerContractDecorator do
+    let(:consumer) { ServiceConsumer.new(name: 'Consumer') }
+    let(:provider) { ServiceProvider.new(name: 'Provider') }
+    let(:consumer_contract) { Pact::ConsumerContract.new(consumer: consumer, provider: provider, interactions: interactions) }
+    let(:pact_specification_version) { '1' }
+    subject { ConsumerContractDecorator.new(consumer_contract, pact_specification_version: pact_specification_version) }
 
     describe "to_json" do
-      let(:consumer) { ServiceConsumer.new(name: 'Consumer') }
-      let(:provider) { ServiceProvider.new(name: 'Provider') }
       let(:interactions) { [] }
-      let(:consumer_contract) { Pact::ConsumerContract.new(consumer: consumer, provider: provider, interactions: interactions) }
-      subject { ConsumerContractDecorator.new(consumer_contract, pact_specification_version: pact_specification_version) }
       let(:parsed_json) { JSON.parse(subject.to_json, symbolize_names: true) }
 
       context "when pact_specification_version is 1" do
@@ -33,5 +34,21 @@ module Pact
       end
 
     end
+    describe "as_json" do
+      context "with multiple interactions" do
+        let(:interaction_1) { InteractionFactory.create(provider_state: 'BBB')  }
+        let(:interaction_2) { InteractionFactory.create(provider_state: 'AAA')}
+        let(:interactions) { [interaction_1, interaction_2] }
+
+
+        it "sorts interactions by provider_state" do
+          expect(subject.as_json[:interactions]).to eq([
+            InteractionDecorator.new(interaction_2, pact_specification_version: pact_specification_version).as_json, 
+            InteractionDecorator.new(interaction_1, pact_specification_version: pact_specification_version).as_json
+            ])
+        end
+      end
+    end
+    
   end
 end

--- a/spec/lib/pact/consumer_contract/consumer_contract_decorator_spec.rb
+++ b/spec/lib/pact/consumer_contract/consumer_contract_decorator_spec.rb
@@ -36,19 +36,98 @@ module Pact
     end
     describe "as_json" do
       context "with multiple interactions" do
-        let(:interaction_1) { InteractionFactory.create(provider_state: 'BBB')  }
-        let(:interaction_2) { InteractionFactory.create(provider_state: 'AAA')}
+        let(:desc_2) { 'Desc 1' }
+        let(:status_2) { 200 }
+        let(:provider_state_2) { 'State 1' }
+        let(:interaction_1) do
+          InteractionFactory.create(
+            provider_state: 'State 2',
+            description: 'Desc 2',
+            response: {
+              status: 201
+            })
+        end
+        let(:interaction_2) do
+          InteractionFactory.create(
+            provider_state: provider_state_2,
+            description: desc_2,
+            response: {
+              status: status_2
+            })
+        end
         let(:interactions) { [interaction_1, interaction_2] }
 
-
-        it "sorts interactions by provider_state" do
+        it "sorts interactions in recorded order by default" do
           expect(subject.as_json[:interactions]).to eq([
-            InteractionDecorator.new(interaction_2, pact_specification_version: pact_specification_version).as_json, 
-            InteractionDecorator.new(interaction_1, pact_specification_version: pact_specification_version).as_json
+            InteractionDecorator.new(interaction_1, pact_specification_version: pact_specification_version).as_json,
+            InteractionDecorator.new(interaction_2, pact_specification_version: pact_specification_version).as_json,
+          ])
+        end
+
+        context "when pactfile_write_order is set to :chronological" do
+          before do
+            Pact.configuration.pactfile_write_order = :chronological
+          end
+
+          it "sorts interactions in recorded order" do
+            expect(subject.as_json[:interactions]).to eq([
+              InteractionDecorator.new(interaction_1, pact_specification_version: pact_specification_version).as_json,
+              InteractionDecorator.new(interaction_2, pact_specification_version: pact_specification_version).as_json,
             ])
+          end
+        end
+
+        context "when pactfile_write_order is set to :alphabetical" do
+          before do
+            Pact.configuration.pactfile_write_order = :alphabetical
+          end
+
+          context "and interactions have different provider state" do
+            let(:desc_2) { 'Desc 2' }
+            let(:status_2) { 201 }
+            it "sorts interactions in alphabetical order by provider state" do
+              expect(subject.as_json[:interactions]).to eq([
+                InteractionDecorator.new(interaction_2, pact_specification_version: pact_specification_version).as_json,
+                InteractionDecorator.new(interaction_1, pact_specification_version: pact_specification_version).as_json,
+              ])
+            end
+          end
+
+          context "and interactions have different description" do
+            let(:status_2) { 201 }
+            let(:provider_state_2) { 'State 2' }
+
+            it "sorts interactions in alphabetical order by description" do
+              expect(subject.as_json[:interactions]).to eq([
+                InteractionDecorator.new(interaction_2, pact_specification_version: pact_specification_version).as_json,
+                InteractionDecorator.new(interaction_1, pact_specification_version: pact_specification_version).as_json,
+              ])
+            end
+          end
+          context "and interactions have different provider state" do
+            let(:status_2) { 201 }
+            let(:desc_2) { 'Desc 2' }
+
+            it "sorts interactions in alphabetical order by description" do
+              expect(subject.as_json[:interactions]).to eq([
+                InteractionDecorator.new(interaction_2, pact_specification_version: pact_specification_version).as_json,
+                InteractionDecorator.new(interaction_1, pact_specification_version: pact_specification_version).as_json,
+              ])
+            end
+          end
+        end
+
+        context "when pactfile_write_order does not have a correct value" do
+          before do
+            Pact.configuration.pactfile_write_order = :not_implemented
+          end
+
+          it "fails" do
+            expect{ subject.as_json[:interactions] }.to raise_error
+          end
         end
       end
     end
-    
+
   end
 end


### PR DESCRIPTION
In order to avoid unnecessary contract file changes. 

Generally RSpec does not execute tests in alphabetical order, it means that if you run the test without any changes several times, it creates pact contract with interactions in random order too.
As a result you need to be careful to understand do you have any changes in pact contract or just commit changes every time it changes the contract.