### PR TITLE
Fix "No entry for terminal..." warning

### DIFF
--- a/packaging/wrapper.sh
+++ b/packaging/wrapper.sh
@@ -22,4 +22,4 @@ export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.
-exec "$LIBDIR/ruby/bin/ruby" -rbundler/setup -I$LIBDIR/app/lib "$LIBDIR/app/pact-mock-service.rb" $@
+exec "$LIBDIR/ruby/bin/ruby" -rreadline -rbundler/setup -I$LIBDIR/app/lib "$LIBDIR/app/pact-mock-service.rb" $@


### PR DESCRIPTION
Fixes the [warning](https://github.com/pact-foundation/pact-mock-service-npm#known-issues) on run:

```
No entry for terminal type "xterm-256color";
using dumb terminal settings.
```

I removed this for https://github.com/pact-foundation/pact-provider-verifier and that seemed to do the trick.