### PR TITLE
Write contract file only when there are interactions for it

### DIFF
--- a/lib/pact/consumer_contract/consumer_contract_writer.rb
+++ b/lib/pact/consumer_contract/consumer_contract_writer.rb
@@ -34,7 +34,7 @@ module Pact
     end
 
     def write
-      update_pactfile unless pactfile_write_mode == :none
+      update_pactfile_if_needed
       pact_json
     end
 
@@ -45,6 +45,12 @@ module Pact
     private
 
     attr_reader :consumer_contract_details, :pactfile_write_mode, :interactions, :logger, :pact_specification_version
+
+    def update_pactfile_if_needed
+      return if pactfile_write_mode == :none
+      return if interactions.count == 0
+      update_pactfile
+    end
 
     def update_pactfile
       logger.info log_message


### PR DESCRIPTION
# The Problem
We run RSec parallelized on CircleCI. CircleCI divides the spec files among multiple containers, and currently each container's RSpec run generates a contract file. These contract files are stored as build artifacts by CircleCI so that they can be fetched by the providers when they run pact verification.

Currently, if you run RSpec on any specific spec file(s) that do not include a pact spec file, it will generate a contract for that pact anyway, containing no interactions. So in our use case, every container generates a contract file, and only one of them contains interactions. CircleCI then chooses one of the container's artifacts (seemingly at random). This results in pact verification on the provider always passing since there are no interactions that might fail.

You can also reproduce this issue locally if you have more than one pact spec.

```sh
# rspec spec/service_providers/provider_a_spec.rb
# cat spec/pacts/consumer_a-provider_b.json
{
  "consumer" : {
    "name" : "Consumer A"
  },
  "provider" : {
    "name" : "Provider B"
  },
  "interactions" : [],
  "metadata" : {
    "pactSpecificationVersion" : "2.0.0"
  }
}
```

# The Proposed Fix
This modification causes the consumer file to be generated only if there will be interactions in it.

If this is not good default behavior, this could be controlled using an configurable setting (similar to `pactfile_write_mode`), but don't want to do that unless there's a call for it.