### PR TITLE
use ssl when checking if https server is up

### DIFF
--- a/lib/pact/mock_service/cli.rb
+++ b/lib/pact/mock_service/cli.rb
@@ -14,7 +14,7 @@ module Pact
       method_option :port, aliases: "-p", desc: "Port on which to run the service"
       method_option :host, aliases: "-h", desc: "Host on which to bind the service", default: 'localhost'
       method_option :log, aliases: "-l", desc: "File to which to log output"
-      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS"
+      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS", type: :boolean, default: false
       method_option :cors, aliases: "-o", desc: "Support browser security in tests by responding to OPTIONS requests and adding CORS headers to mocked responses"
       method_option :pact_dir, aliases: "-d", desc: "Directory to which the pacts will be written"
       method_option :pact_specification_version, aliases: "-i", desc: "The pact specification version to use when writing the pact", default: '1'
@@ -32,7 +32,7 @@ module Pact
       method_option :log_dir, aliases: "-l", desc: "File to which to log output"
       method_option :pact_dir, aliases: "-d", desc: "Directory to which the pacts will be written"
       method_option :pact_specification_version, aliases: "-i", desc: "The pact specification version to use when writing the pact", default: '1'
-      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS"
+      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS", type: :boolean, default: false
       method_option :cors, aliases: "-o", desc: "Support browser security in tests by responding to OPTIONS requests and adding CORS headers to mocked responses"
 
       def control
@@ -44,7 +44,7 @@ module Pact
       method_option :port, aliases: "-p", default: '1234', desc: "Port on which to run the service"
       method_option :host, aliases: "-h", desc: "Host on which to bind the service", default: 'localhost'
       method_option :log, aliases: "-l", desc: "File to which to log output"
-      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS"
+      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS", type: :boolean, default: false
       method_option :cors, aliases: "-o", desc: "Support browser security in tests by responding to OPTIONS requests and adding CORS headers to mocked responses"
       method_option :pact_dir, aliases: "-d", desc: "Directory to which the pacts will be written"
       method_option :pact_specification_version, aliases: "-i", desc: "The pact specification version to use when writing the pact", default: '1'
@@ -70,7 +70,7 @@ module Pact
       method_option :port, aliases: "-p", default: '1234', desc: "Port on which to run the service"
       method_option :host, aliases: "-h", desc: "Host on which to bind the service", default: 'localhost'
       method_option :log, aliases: "-l", desc: "File to which to log output"
-      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS"
+      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS", type: :boolean, default: false
       method_option :cors, aliases: "-o", desc: "Support browser security in tests by responding to OPTIONS requests and adding CORS headers to mocked responses"
       method_option :pact_dir, aliases: "-d", desc: "Directory to which the pacts will be written"
       method_option :pact_specification_version, aliases: "-i", desc: "The pact specification version to use when writing the pact", default: '1'
@@ -87,7 +87,7 @@ module Pact
       desc 'control-start', "Start a Pact mock service control server."
       method_option :port, aliases: "-p", desc: "Port on which to run the service", default: '1234'
       method_option :log_dir, aliases: "-l", desc: "File to which to log output", default: "log"
-      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS"
+      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS", type: :boolean, default: false
       method_option :cors, aliases: "-o", desc: "Support browser security in tests by responding to OPTIONS requests and adding CORS headers to mocked responses"
       method_option :pact_dir, aliases: "-d", desc: "Directory to which the pacts will be written", default: "."
       method_option :pact_specification_version, aliases: "-i", desc: "The pact specification version to use when writing the pact", default: '1'
@@ -110,7 +110,7 @@ module Pact
       desc 'control-restart', "Start a Pact mock service control server."
       method_option :port, aliases: "-p", desc: "Port on which to run the service", default: '1234'
       method_option :log_dir, aliases: "-l", desc: "File to which to log output", default: "log"
-      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS"
+      method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS", type: :boolean, default: false
       method_option :cors, aliases: "-o", desc: "Support browser security in tests by responding to OPTIONS requests and adding CORS headers to mocked responses"
       method_option :pact_dir, aliases: "-d", desc: "Directory to which the pacts will be written", default: "."
       method_option :pact_specification_version, aliases: "-i", desc: "The pact specification version to use when writing the pact", default: '1'
@@ -144,14 +144,14 @@ module Pact
 
         def start_server pidfile
           require 'pact/mock_service/server/spawn'
-          Pact::MockService::Server::Spawn.(pidfile, options[:port]) do
+          Pact::MockService::Server::Spawn.(pidfile, options[:port], options[:ssl]) do
             yield
           end
         end
 
         def restart_server pidfile
           require 'pact/mock_service/server/respawn'
-          Pact::MockService::Server::Respawn.(pidfile, options[:port]) do
+          Pact::MockService::Server::Respawn.(pidfile, options[:port], options[:ssl]) do
             yield
           end
         end

--- a/lib/pact/mock_service/server/respawn.rb
+++ b/lib/pact/mock_service/server/respawn.rb
@@ -5,12 +5,12 @@ module Pact
     module Server
       class Respawn
 
-        def self.call pidfile, port
+        def self.call pidfile, port, ssl = false
           if pidfile.file_exists_and_process_running?
             pidfile.kill_process
           end
 
-          Spawn.(pidfile, port) do
+          Spawn.(pidfile, port, ssl) do
             yield
           end
         end

--- a/lib/pact/mock_service/server/spawn.rb
+++ b/lib/pact/mock_service/server/spawn.rb
@@ -7,7 +7,7 @@ module Pact
 
         class PortUnavailableError < StandardError; end
 
-        def self.call pidfile, port
+        def self.call pidfile, port, ssl = false
           if pidfile.can_start?
             if port_available? port
               pid = fork do
@@ -15,7 +15,7 @@ module Pact
               end
               pidfile.pid = pid
               Process.detach(pid)
-              Server::WaitForServerUp.(port)
+              Server::WaitForServerUp.(port, {ssl: ssl})
               pidfile.write
             else
               raise PortUnavailableError.new("ERROR: Port #{port} already in use.")

--- a/spec/integration/cli_ssl_spec.rb
+++ b/spec/integration/cli_ssl_spec.rb
@@ -10,13 +10,12 @@ describe "The pact-mock-service command line interface, with SSL", mri_only: tru
   end
 
   it "should respond with SSL" do
-    response = wait_until_server_started_on_ssl 4343
-    expect(response.status).to eq 200
+    wait_until_server_started 4343, true
   end
 
   it "sets the X-Pact-Mock-Service-Location header with https" do
-    wait_until_server_started_on_ssl 4343
-    response = wait_until_server_started_on_ssl 4343
+    wait_until_server_started 4343, true
+    response = connect_via_ssl 4343
     expect(response.headers['X-Pact-Mock-Service-Location']).to eq 'https://0.0.0.0:4343'
   end
 

--- a/spec/support/integration_spec_support.rb
+++ b/spec/support/integration_spec_support.rb
@@ -14,7 +14,7 @@ module Pact
         exec "bundle exec bin/pact-mock-service --port #{port} --host 0.0.0.0 --log tmp/integration.log --pact-dir tmp/pacts #{options}"
       end
 
-      wait_until_server_started(port) if wait
+      wait_until_server_started(port, /--ssl/ === options) if wait
       pid
     end
 
@@ -27,20 +27,8 @@ module Pact
       pid
     end
 
-    def wait_until_server_started port
-      Pact::MockService::Server::WaitForServerUp.(port)
-    end
-
-    def wait_until_server_started_on_ssl port
-      tries = 0
-      begin
-        connect_via_ssl port
-      rescue Faraday::ConnectionFailed => e
-        sleep 0.1
-        tries += 1
-        retry if tries < 100
-        raise "Could not connect to server"
-      end
+    def wait_until_server_started port, ssl = false
+      Pact::MockService::Server::WaitForServerUp.(port, {ssl: ssl})
     end
 
     def kill_server pid


### PR DESCRIPTION
Updated WaitForServerUp to use SSL if mock service was started with --ssl option. Currently it fails after 100 failed http get checks.